### PR TITLE
Add test setup helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: setup
+
+setup:
+	bash scripts/setup.sh

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-Blockchain based royalty payment platform 
+# RoyaltyRails
+
+Blockchain based royalty payment platform.
+
+## Running Tests
+
+The test suite depends on Python packages listed in `requirements.txt`. Install them before running tests:
+
+```bash
+pip install -r requirements.txt
+```
+
+Because packages are downloaded from PyPI, network access may be required during this step.
+
+You can use the provided Makefile or setup script to install these dependencies:
+
+```bash
+make setup
+# or
+./scripts/setup.sh
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+# Add package requirements here

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Install Python dependencies for tests
+set -euo pipefail
+
+if [ ! -f requirements.txt ]; then
+  echo "requirements.txt not found" >&2
+  exit 1
+fi
+
+pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- document how to install requirements for tests
- add a helper setup script
- provide a simple Makefile for convenience

## Testing
- `bash scripts/setup.sh`
- `make setup`


------
https://chatgpt.com/codex/tasks/task_e_688271410394832aa9b74c483ebd10ac